### PR TITLE
fix: apply responsive corrections

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
     <main class="w-11/12 h-[85vh] self-center flex flex-row">
       <div
         id="list"
-        class="w-[70%] justify-center gap-3 p-3 overflow-y-auto flex flex-wrap"
+        class="w-auto justify-center gap-3 p-3 overflow-y-auto flex flex-wrap"
       ></div>
 
       <div

--- a/src/js/components.js
+++ b/src/js/components.js
@@ -65,7 +65,7 @@ export const cardBase = (id, children) => {
   const div = document.createElement("div");
   div.id = `card-pokemon-${id}`;
   setAttributeClasses(div, [
-    "w-52",
+    "w-[100%]",
     "h-44",
     "rounded-2xl",
     "bg-slate-50",
@@ -76,6 +76,9 @@ export const cardBase = (id, children) => {
     "gap-2",
     "cursor-pointer",
     "hover:bg-slate-200",
+    "md:w-72",
+    "lg:w-62",
+    "xl:w-52",
   ]);
 
   div.addEventListener("click", () => createDetailComponent(id));

--- a/src/js/detail.js
+++ b/src/js/detail.js
@@ -21,12 +21,14 @@ export const closeDetail = () => {
 };
 
 export function createDetailComponent(id) {
-  if (window.innerWidth < 600) {
+  if (window.innerWidth < 900) {
     pokemonList.classList.add("hidden");
+    
     pokemonDetail.classList.remove("w-[30%]");
     pokemonDetail.classList.add("w-[100%]");
   } else {
     pokemonList.classList.remove("hidden");
+
     pokemonDetail.classList.add("w-[30%]");
     pokemonDetail.classList.remove("w-[100%]");
   }


### PR DESCRIPTION
## Descrição do Pull Request

### Resumo das Alterações

Este pull request aborda os problemas identificados na issue relacionada "Responsive layout don't work," com base no commit:

- **"fix: apply responsive corrections"**
  - Aplica correções responsivas para resolver os seguintes problemas:
    1. **Tamanho inadequado dos cards em telas pequenas:**
       - Corrige o dimensionamento inadequado dos cards de Pokémon em telas pequenas, garantindo uma exibição apropriada em dispositivos móveis.
    2. **Problema no detalhamento do Pokémon em telas maiores (entre 600px e 900px):**
       - Implementa correções no layout de detalhes do Pokémon para evitar quebras em larguras de tela entre 600px e 900px.

### Testes Realizados

- Verificou-se a aplicação adequada das correções responsivas.
- Testou-se a exibição dos cards em telas pequenas.
- Validou-se o layout de detalhes do Pokémon em telas maiores que 600px e menores que 900px.

### Issue Relacionada

Este pull request resolve a seguinte issue:
- [Responsive layout don't work bug #4](https://github.com/DWRP/pokedex-dio/issues/4)

### Ambiente

- Navegador: Chrome
- Dispositivo: Iphone SE (Chrome debug)
